### PR TITLE
Target 1.20.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
   <groupId>uk.firedev</groupId>
   <artifactId>EMFPinata</artifactId>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <name>EMFPiñata</name>
   <description>A Piñata addon for the EvenMoreFish plugin.</description>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -48,19 +48,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <!-- For 1.20.5+ -->
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.1</version>
-          <configuration>
-              <archive>
-                  <manifestEntries>
-                      <paperweight-mappings-namespace>spigot</paperweight-mappings-namespace>
-                  </manifestEntries>
-              </archive>
-          </configuration>
       </plugin>
     </plugins>
     <resources>
@@ -97,7 +84,7 @@
       <dependency>
           <groupId>io.papermc.paper</groupId>
           <artifactId>paper-api</artifactId>
-          <version>1.20.4-R0.1-SNAPSHOT</version>
+          <version>1.20.6-R0.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
       <dependency>
@@ -109,8 +96,8 @@
       </dependency>
       <dependency>
           <groupId>dev.jorel</groupId>
-          <artifactId>commandapi-bukkit-shade</artifactId>
-          <version>9.4.1</version>
+          <artifactId>commandapi-bukkit-shade-mojang-mapped</artifactId>
+          <version>9.4.2</version>
           <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/src/main/java/uk/firedev/emfpinata/EMFPinata.java
+++ b/src/main/java/uk/firedev/emfpinata/EMFPinata.java
@@ -22,7 +22,6 @@ public final class EMFPinata extends JavaPlugin {
         CommandAPI.onEnable();
         reload();
         registerCommands();
-        System.out.println(NamedTextColor.NAMES.values());
     }
 
     public static EMFPinata getInstance() { return instance; }


### PR DESCRIPTION
- The plugin's version is now 1.0.1

- Target Java 21
- Bump paper-api to 1.20.6-R0.1-SNAPSHOT
- commandapi-bukkit-shade -> commandapi-bukkit-shade-mojang-mapped
- Bump commandapi-bukkit-shade-mojang-mapped to 9.4.2
- Remove paperweight remapping configuration