### PR TITLE
Support MythicMobs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,11 +13,13 @@ repositories {
     gradlePluginPortal()
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://repo.firedev.uk/repository/maven-public/")
+    maven("https://mvn.lumine.io/repository/maven-public/")
 }
 
 dependencies {
     compileOnly(libs.paper.api)
     compileOnly(files("$projectDir/libs/even-more-fish-1.7.3-RELEASE.jar"))
+    compileOnly(libs.mythicmobs)
 
     implementation(libs.commandapi)
     implementation(libs.bstats)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,10 @@ paper {
             required = true
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }
+        register("MythicMobs") {
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ dependencyResolutionManagement {
             library("evenmorefish", "com.oheers:EvenMoreFish:1.7.3")
             library("commandapi", "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.5.3")
             library("bstats", "org.bstats:bstats-bukkit:3.0.2")
+            library("mythicmobs", "io.lumine:Mythic-Dist:5.6.1")
 
             plugin("shadow", "com.gradleup.shadow").version("8.3.1")
             plugin("plugin-yml", "net.minecrell.plugin-yml.paper").version("0.6.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
             library("evenmorefish", "com.oheers:EvenMoreFish:1.7.3")
             library("commandapi", "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.5.3")
             library("bstats", "org.bstats:bstats-bukkit:3.0.2")
-            library("mythicmobs", "io.lumine:Mythic-Dist:5.6.1")
+            library("mythicmobs", "io.lumine:Mythic-Dist:5.7.1")
 
             plugin("shadow", "com.gradleup.shadow").version("8.3.1")
             plugin("plugin-yml", "net.minecrell.plugin-yml.paper").version("0.6.0")

--- a/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
+++ b/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
@@ -44,7 +44,7 @@ public class PinataConfig extends ConfigBase {
                 String mythicMobType = type.replaceFirst("mythicmob:", "");
                 pinataType = new MythicMobsPinata(key, mythicMobType, displayName);
             } else {
-                pinataType = new Pinata(key, pinataSection.getString("entity-type", "llama"), displayName);
+                pinataType = new Pinata(key, type, displayName);
             }
             pinataType.setGlowing(pinataSection.getBoolean("glowing", true));
             pinataType.setHealth(pinataSection.getInt("health", 120));

--- a/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
+++ b/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
@@ -5,7 +5,9 @@ import com.oheers.fish.libs.boostedyaml.block.implementation.Section;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 import uk.firedev.emfpinata.EMFPinata;
-import uk.firedev.emfpinata.pinatas.Pinata;
+import uk.firedev.emfpinata.pinatas.PinataType;
+import uk.firedev.emfpinata.pinatas.internal.MythicMobsPinata;
+import uk.firedev.emfpinata.pinatas.internal.Pinata;
 import uk.firedev.emfpinata.pinatas.PinataManager;
 
 public class PinataConfig extends ConfigBase {
@@ -33,20 +35,22 @@ public class PinataConfig extends ConfigBase {
             if (pinataSection == null) {
                 return;
             }
-            @NotNull EntityType entityType;
-            try {
-                entityType = EntityType.valueOf(pinataSection.getString("entity-type", "llama").toUpperCase());
-            } catch (IllegalArgumentException ex) {
-                entityType = EntityType.LLAMA;
+            String displayName = pinataSection.getString("display-name");
+            String type = pinataSection.getString("entity-type", "llama");
+            PinataType pinataType;
+            if (type.startsWith("mythicmob:")) {
+                String mythicMobType = type.replaceFirst("mythicmob:", "");
+                pinataType = new MythicMobsPinata(key, mythicMobType, displayName);
+            } else {
+                pinataType = new Pinata(key, pinataSection.getString("entity-type", "llama"), displayName);
             }
-            Pinata pinata = new Pinata(key, entityType, pinataSection.getString("display-name"));
-            pinata.setGlowing(pinataSection.getBoolean("glowing", true));
-            pinata.setHealth(pinataSection.getInt("health", 120));
-            pinata.setSilent(pinataSection.getBoolean("silent", true));
-            pinata.setGlowColor(pinataSection.getString("glow-color", "aqua").toUpperCase());
-            pinata.setRewards(pinataSection.getStringList("rewards"));
-            pinata.setAware(pinataSection.getBoolean("has-awareness"));
-            pinata.register();
+            pinataType.setGlowing(pinataSection.getBoolean("glowing", true));
+            pinataType.setHealth(pinataSection.getInt("health", 120));
+            pinataType.setSilent(pinataSection.getBoolean("silent", true));
+            pinataType.setGlowColor(pinataSection.getString("glow-color", "aqua").toUpperCase());
+            pinataType.setRewards(pinataSection.getStringList("rewards"));
+            pinataType.setAware(pinataSection.getBoolean("has-awareness"));
+            pinataType.register();
         });
     }
 

--- a/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
+++ b/src/main/java/uk/firedev/emfpinata/config/PinataConfig.java
@@ -2,6 +2,7 @@ package uk.firedev.emfpinata.config;
 
 import com.oheers.fish.config.ConfigBase;
 import com.oheers.fish.libs.boostedyaml.block.implementation.Section;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 import uk.firedev.emfpinata.EMFPinata;
@@ -30,6 +31,7 @@ public class PinataConfig extends ConfigBase {
         if (section == null) {
             return;
         }
+        boolean mythicMobsEnabled = Bukkit.getPluginManager().isPluginEnabled("MythicMobs");
         section.getRoutesAsStrings(false).forEach(key -> {
             Section pinataSection = section.getSection(key);
             if (pinataSection == null) {
@@ -38,7 +40,7 @@ public class PinataConfig extends ConfigBase {
             String displayName = pinataSection.getString("display-name");
             String type = pinataSection.getString("entity-type", "llama");
             PinataType pinataType;
-            if (type.startsWith("mythicmob:")) {
+            if (mythicMobsEnabled && type.startsWith("mythicmob:")) {
                 String mythicMobType = type.replaceFirst("mythicmob:", "");
                 pinataType = new MythicMobsPinata(key, mythicMobType, displayName);
             } else {

--- a/src/main/java/uk/firedev/emfpinata/pinatas/PinataType.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/PinataType.java
@@ -21,8 +21,6 @@ public interface PinataType {
 
     String getIdentifier();
 
-    Entity getEntity(@NotNull Location location);
-
     String getDisplayName();
 
     void setDisplayName(@NotNull String displayName);
@@ -65,34 +63,7 @@ public interface PinataType {
         return PinataManager.getInstance().registerPinata(this);
     }
 
-    default void spawn(@NotNull Location location) {
-        World world = location.getWorld();
-        if (world == null) {
-            EMFPinata.getInstance().getLogger().warning("Invalid world!");
-            return;
-        }
-        LivingEntity entity = (LivingEntity) location.getWorld().spawnEntity(location, getEntityType());
-        if (getDisplayName() != null) {
-            entity.setCustomNameVisible(true);
-            entity.customName(EMFPinata.getInstance().getMiniMessage().deserialize(getDisplayName()));
-        }
-        entity.setGlowing(isGlowing());
-        if (getGlowColor() != null && !getGlowColor().isEmpty()) {
-            ScoreboardHelper.getInstance().addToTeam(entity, getGlowColor());
-        }
-        AttributeInstance attribute = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attribute != null) {
-            attribute.setBaseValue(getHealth());
-            entity.setHealth(getHealth());
-        }
-        entity.setSilent(isSilent());
-        if (entity instanceof Mob mob) {
-            mob.setAware(isAware());
-        }
-        PersistentDataContainer pdc = entity.getPersistentDataContainer();
-        pdc.set(PinataManager.getInstance().getPinataKey(), PersistentDataType.BOOLEAN, true);
-        pdc.set(PinataManager.getInstance().getPinataRewardsKey(), PersistentDataType.LIST.strings(), getRewards());
-    }
+    void spawn(@NotNull Location location);
 
     default void applyCommonValues(@NotNull Entity entity) {
         if (getDisplayName() != null) {

--- a/src/main/java/uk/firedev/emfpinata/pinatas/PinataType.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/PinataType.java
@@ -74,7 +74,7 @@ public interface PinataType {
         if (getGlowColor() != null && !getGlowColor().isEmpty()) {
             ScoreboardHelper.getInstance().addToTeam(entity, getGlowColor());
         }
-        if (entity instanceof LivingEntity livingEntity) {
+        if (getHealth() > 0 && entity instanceof LivingEntity livingEntity) {
             AttributeInstance attribute = livingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH);
             if (attribute != null) {
                 attribute.setBaseValue(getHealth());

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
@@ -1,0 +1,134 @@
+package uk.firedev.emfpinata.pinatas.internal;
+
+import io.lumine.mythic.api.mobs.MythicMob;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.MythicBukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import uk.firedev.emfpinata.pinatas.PinataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MythicMobsPinata implements PinataType {
+
+    private final String identifier;
+    private String displayName;
+    private int health = 20;
+    private boolean glowing = false;
+    private List<String> rewards = new ArrayList<>();
+    private boolean silent = true;
+    private String glowColor = "";
+    private final @NotNull MythicMob mythicMob;
+    private boolean hasAwareness;
+
+    public MythicMobsPinata(@NotNull String identifier, @NotNull String mythicName, @Nullable String displayName) {
+        this.identifier = identifier;
+        this.displayName = displayName;
+        this.mythicMob = MythicBukkit.inst().getMobManager().getMythicMob(mythicName).orElseThrow();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public Entity getEntity(@NotNull Location location) {
+        Entity entity = mythicMob.spawn(BukkitAdapter.adapt(location), 1).getEntity().getBukkitEntity();
+        applyCommonValues(entity);
+        return entity;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public void setDisplayName(@NotNull String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public int getHealth() {
+        return health;
+    }
+
+    @Override
+    public void setHealth(int health) {
+        if (health <= 0) {
+            health = 1;
+        }
+        this.health = health;
+    }
+
+    @Override
+    public boolean isGlowing() {
+        return glowing;
+    }
+
+    @Override
+    public void setGlowing(boolean glowing) {
+        this.glowing = glowing;
+    }
+
+    @Override
+    public boolean isAware() {
+        return hasAwareness;
+    }
+
+    @Override
+    public void setAware(boolean hasAwareness) {
+        this.hasAwareness = hasAwareness;
+    }
+
+    @Override
+    public List<String> getRewards() {
+        return rewards;
+    }
+
+    @Override
+    public void setRewards(@NotNull List<String> rewards) {
+        this.rewards = new ArrayList<>(rewards);
+    }
+
+    @Override
+    public void addReward(@NotNull String reward) {
+        this.rewards.add(reward);
+    }
+
+    @Override
+    public void addRewards(@NotNull String... rewards) {
+        this.rewards.addAll(Arrays.asList(rewards));
+    }
+
+    @Override
+    public void addRewards(@NotNull List<String> rewards) {
+        this.rewards.addAll(rewards);
+    }
+
+    @Override
+    public boolean isSilent() {
+        return silent;
+    }
+
+    @Override
+    public void setSilent(boolean silent) {
+        this.silent = silent;
+    }
+
+    @Override
+    public String getGlowColor() {
+        return glowColor;
+    }
+
+    @Override
+    public void setGlowColor(@NotNull String glowColor) {
+        this.glowColor = glowColor;
+    }
+
+}

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
@@ -17,7 +17,7 @@ public class MythicMobsPinata implements PinataType {
 
     private final String identifier;
     private String displayName;
-    private int health = 20;
+    private int health = 0;
     private boolean glowing = false;
     private List<String> rewards = new ArrayList<>();
     private boolean silent = true;
@@ -59,9 +59,6 @@ public class MythicMobsPinata implements PinataType {
 
     @Override
     public void setHealth(int health) {
-        if (health <= 0) {
-            health = 1;
-        }
         this.health = health;
     }
 

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
@@ -5,8 +5,10 @@ import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.emfpinata.EMFPinata;
 import uk.firedev.emfpinata.pinatas.PinataType;
 
 import java.util.ArrayList;
@@ -22,13 +24,17 @@ public class MythicMobsPinata implements PinataType {
     private List<String> rewards = new ArrayList<>();
     private boolean silent = true;
     private String glowColor = "";
-    private final @NotNull MythicMob mythicMob;
+    private final String mythicName;
     private boolean hasAwareness;
 
     public MythicMobsPinata(@NotNull String identifier, @NotNull String mythicName, @Nullable String displayName) {
         this.identifier = identifier;
         this.displayName = displayName;
-        this.mythicMob = MythicBukkit.inst().getMobManager().getMythicMob(mythicName).orElseThrow();
+        this.mythicName = mythicName;
+    }
+
+    public @Nullable MythicMob getMythicMob() {
+        return MythicBukkit.inst().getMobManager().getMythicMob(mythicName).orElse(null);
     }
 
     @Override
@@ -38,7 +44,14 @@ public class MythicMobsPinata implements PinataType {
 
     @Override
     public void spawn(@NotNull Location location) {
-        Entity entity = mythicMob.spawn(BukkitAdapter.adapt(location), 1).getEntity().getBukkitEntity();
+        MythicMob mythicMob = getMythicMob();
+        Entity entity;
+        if (mythicMob == null) {
+            EMFPinata.getInstance().getLogger().warning(mythicName + " is not a valid MythicMob! Defaulting to LLAMA.");
+            entity = location.getWorld().spawnEntity(location, EntityType.LLAMA);
+        } else {
+            entity = mythicMob.spawn(BukkitAdapter.adapt(location), 1).getEntity().getBukkitEntity();
+        }
         applyCommonValues(entity);
     }
 

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/MythicMobsPinata.java
@@ -37,10 +37,9 @@ public class MythicMobsPinata implements PinataType {
     }
 
     @Override
-    public Entity getEntity(@NotNull Location location) {
+    public void spawn(@NotNull Location location) {
         Entity entity = mythicMob.spawn(BukkitAdapter.adapt(location), 1).getEntity().getBukkitEntity();
         applyCommonValues(entity);
-        return entity;
     }
 
     @Override

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
@@ -143,10 +143,9 @@ public class Pinata implements PinataType {
     }
 
     @Override
-    public Entity getEntity(@NotNull Location location) {
+    public void spawn(@NotNull Location location) {
         Entity entity = location.getWorld().spawnEntity(location, getEntityType());
         applyCommonValues(entity);
-        return entity;
     }
 
 }

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
@@ -24,7 +24,7 @@ public class Pinata implements PinataType {
 
     private final String identifier;
     private String displayName;
-    private int health = 20;
+    private int health = 0;
     private boolean glowing = false;
     private List<String> rewards = new ArrayList<>();
     private boolean silent = true;
@@ -71,9 +71,6 @@ public class Pinata implements PinataType {
 
     @Override
     public void setHealth(int health) {
-        if (health <= 0) {
-            health = 1;
-        }
         this.health = health;
     }
 

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
@@ -1,8 +1,20 @@
-package uk.firedev.emfpinata.pinatas;
+package uk.firedev.emfpinata.pinatas.internal;
 
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.emfpinata.EMFPinata;
+import uk.firedev.emfpinata.ScoreboardHelper;
+import uk.firedev.emfpinata.pinatas.PinataManager;
+import uk.firedev.emfpinata.pinatas.PinataType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,9 +32,16 @@ public class Pinata implements PinataType {
     private final EntityType entityType;
     private boolean hasAwareness;
 
-    public Pinata(@NotNull String identifier, @NotNull EntityType entityType, @Nullable String displayName) {
+    public Pinata(@NotNull String identifier, @NotNull String entityTypeString, @Nullable String displayName) {
         this.identifier = identifier;
         this.displayName = displayName;
+
+        @NotNull EntityType entityType;
+        try {
+            entityType = EntityType.valueOf(entityTypeString.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            entityType = EntityType.LLAMA;
+        }
         this.entityType = entityType;
     }
 
@@ -31,7 +50,6 @@ public class Pinata implements PinataType {
         return identifier;
     }
 
-    @Override
     public EntityType getEntityType() {
         return entityType;
     }
@@ -41,6 +59,7 @@ public class Pinata implements PinataType {
         return displayName;
     }
 
+    @Override
     public void setDisplayName(@NotNull String displayName) {
         this.displayName = displayName;
     }
@@ -50,6 +69,7 @@ public class Pinata implements PinataType {
         return health;
     }
 
+    @Override
     public void setHealth(int health) {
         if (health <= 0) {
             health = 1;
@@ -62,6 +82,7 @@ public class Pinata implements PinataType {
         return hasAwareness;
     }
 
+    @Override
     public void setAware(boolean hasAwareness) {
         this.hasAwareness = hasAwareness;
     }
@@ -71,6 +92,7 @@ public class Pinata implements PinataType {
         return glowing;
     }
 
+    @Override
     public void setGlowing(boolean glowing) {
         this.glowing = glowing;
     }
@@ -80,18 +102,22 @@ public class Pinata implements PinataType {
         return rewards;
     }
 
+    @Override
     public void setRewards(@NotNull List<String> rewards) {
         this.rewards = new ArrayList<>(rewards);
     }
 
+    @Override
     public void addReward(@NotNull String reward) {
         this.rewards.add(reward);
     }
 
+    @Override
     public void addRewards(@NotNull String... rewards) {
-        this.rewards.addAll(Arrays.stream(rewards).toList());
+        this.rewards.addAll(Arrays.asList(rewards));
     }
 
+    @Override
     public void addRewards(@NotNull List<String> rewards) {
         this.rewards.addAll(rewards);
     }
@@ -101,6 +127,7 @@ public class Pinata implements PinataType {
         return silent;
     }
 
+    @Override
     public void setSilent(boolean silent) {
         this.silent = silent;
     }
@@ -110,8 +137,16 @@ public class Pinata implements PinataType {
         return glowColor;
     }
 
+    @Override
     public void setGlowColor(@NotNull String glowColor) {
         this.glowColor = glowColor;
+    }
+
+    @Override
+    public Entity getEntity(@NotNull Location location) {
+        Entity entity = location.getWorld().spawnEntity(location, getEntityType());
+        applyCommonValues(entity);
+        return entity;
     }
 
 }

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
@@ -29,22 +29,13 @@ public class Pinata implements PinataType {
     private List<String> rewards = new ArrayList<>();
     private boolean silent = true;
     private String glowColor = "";
-    private final EntityType entityType;
+    private final String entityTypeString;
     private boolean hasAwareness;
 
     public Pinata(@NotNull String identifier, @NotNull String entityTypeString, @Nullable String displayName) {
         this.identifier = identifier;
         this.displayName = displayName;
-
-        @NotNull EntityType entityType;
-        entityTypeString = entityTypeString.toUpperCase();
-        try {
-            entityType = EntityType.valueOf(entityTypeString);
-        } catch (IllegalArgumentException ex) {
-            EMFPinata.getInstance().getLogger().warning(entityTypeString + " is not a valid entity type. Defaulting to LLAMA.");
-            entityType = EntityType.LLAMA;
-        }
-        this.entityType = entityType;
+        this.entityTypeString = entityTypeString.toUpperCase();
     }
 
     @Override
@@ -53,6 +44,13 @@ public class Pinata implements PinataType {
     }
 
     public EntityType getEntityType() {
+        @NotNull EntityType entityType;
+        try {
+            entityType = EntityType.valueOf(entityTypeString);
+        } catch (IllegalArgumentException ex) {
+            EMFPinata.getInstance().getLogger().warning(entityTypeString + " is not a valid entity type. Defaulting to LLAMA.");
+            entityType = EntityType.LLAMA;
+        }
         return entityType;
     }
 

--- a/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
+++ b/src/main/java/uk/firedev/emfpinata/pinatas/internal/Pinata.java
@@ -37,9 +37,11 @@ public class Pinata implements PinataType {
         this.displayName = displayName;
 
         @NotNull EntityType entityType;
+        entityTypeString = entityTypeString.toUpperCase();
         try {
-            entityType = EntityType.valueOf(entityTypeString.toUpperCase());
+            entityType = EntityType.valueOf(entityTypeString);
         } catch (IllegalArgumentException ex) {
+            EMFPinata.getInstance().getLogger().warning(entityTypeString + " is not a valid entity type. Defaulting to LLAMA.");
             entityType = EntityType.LLAMA;
         }
         this.entityType = entityType;


### PR DESCRIPTION
- Adds support for MythicMobs
- Warns console when a Piñata defaults to LLAMA
- Prevents health from being forced to work with MythicMobs better - 0 health = entity's default